### PR TITLE
Add __block keyword

### DIFF
--- a/after/syntax/objc.vim
+++ b/after/syntax/objc.vim
@@ -3,3 +3,5 @@ syn match objcDirective "@property\|@synthesize\|@dynamic\|@package"
 " ARC type modifiers
 syn keyword objcTypeModifier __bridge __bridge_retained __bridge_transfer __autoreleasing __strong __weak __unsafe_unretained
 
+" Block modifiers
+syn keyword objcTypeModifier __block


### PR DESCRIPTION
Hi,

Here's a little patch adding `__block` to the list of keywords. Both the vim-shipped Objective-C syntax files and Cocoa.vim don't have it, and since Cocoa.vim hasn't been updated for a long while I figured vim-objc would welcome it with a warm heart.
