### PR TITLE
Don't indent after @interface

### DIFF
--- a/after/indent/objc.vim
+++ b/after/indent/objc.vim
@@ -20,7 +20,7 @@ setlocal indentexpr=GetObjCIndentImproved()
 
 " Top level statements which should not be indented, and which should not
 " cause next (non-blank) line to be indented either.
-let s:topLev = '^\s*@\%(class\|end\|implementation\|protocol\|\)\>'
+let s:topLev = '^\s*@\%(class\|end\|implementation\|interface\|protocol\|\)\>'
 
 function! GetObjCIndentImproved()
   " NOTE: Ignore leading white space to avoid having to deal with space vs.


### PR DESCRIPTION
Without this tiny tweak there was an issue when indenting after `@interface`s.

Actual:

```
@interface FooBar ()<enter>

    ^ (cursor)
```

Expected:

```
@interface FooBar ()<enter>

^ (cursor)
```

This only happened when there were trailing `(.*)` like when you were making a class category.
