### PR TITLE
Ensure cinoptions are default

### DIFF
--- a/after/indent/objc.vim
+++ b/after/indent/objc.vim
@@ -14,6 +14,8 @@ set cpo&vim
 "let b:did_indent = 1
 "setlocal cindent
 
+setlocal cinoptions&
+
 setl indentkeys=0{,0},:,0#,!^F,o,O,e,<:>
 
 setlocal indentexpr=GetObjCIndentImproved()


### PR DESCRIPTION
If user changed to nondefault cinoptions, then we want to go back to vim
defaults which work well for C code and are assumed for this indent to
work correctly.

I set `cino=#1` to allow using `#` as a comment by default. I think it makes sense for plugins to explicitly set cinoptions instead of assuming they're at vim default, right?